### PR TITLE
Add dealer bot, refactor code to use fewer strings

### DIFF
--- a/cli_player/cli_player.py
+++ b/cli_player/cli_player.py
@@ -1,5 +1,6 @@
 from engine.engine import PlayerAbstract
-
+from engine.item import Action, ActionOutcome, ActorAction, Item, Nothing, RoundStart
+import time
 
 class CLIPlayer(PlayerAbstract):
     def __init__(self, number, language):
@@ -10,31 +11,40 @@ class CLIPlayer(PlayerAbstract):
             self,
             my_hp: int,
             opponent_hp: int,
-            my_items: list[str],
-            opponent_items: list[str],
-            action: str,
-            action_result: str,
-            available: list[str],
+            my_items: list[Item],
+            opponent_items: list[Item],
+            action: ActorAction,
+            action_outcome: ActionOutcome,
+            available: list[Action],
     ):
-        print(self.language.acting_player(), end='')
-        print(self.number)
+        if not isinstance(action, RoundStart):
+            print(self.language.acting_player(), end='')
+            print(self.number if len(available) > 0 else 'Opponent')
         print(self.language.hp(), end='')
         print(my_hp)
         print(self.language.opponent_hp(), end='')
         print(opponent_hp)
         print(self.language.my_items(), end='')
-        print(my_items)
+        print(', '.join(map(str, my_items)))
         print(self.language.opponent_items(), end='')
-        print(opponent_items)
+        print(', '.join(map(str, opponent_items)))
         print(self.language.action(), end='')
-        print(action)
+        print(str(action))
         print(self.language.action_result(), end='')
-        print(action_result)
+        print(str(action_outcome))
         if len(available) > 0:
-            print(self.language.available_moves(), end='')
-            print(available)
-            move = input(self.language.my_move())
+            move = None
+            text_moves = list(map(lambda x: str(x).lower(), available))
+            while move == None:
+                print(self.language.available_moves(), end='')
+                print(', '.join(map(str, available)))
+                try:
+                    move = available[text_moves.index(input(self.language.my_move()).lower())]
+                except ValueError:
+                    pass
+
         else:
-            move = 'NOTHING'
+            time.sleep(2)
+            move = Nothing()
         print('-----------------------------')
         return move

--- a/cli_player/cli_player.py
+++ b/cli_player/cli_player.py
@@ -25,9 +25,9 @@ class CLIPlayer(PlayerAbstract):
         print(self.language.opponent_hp(), end='')
         print(opponent_hp)
         print(self.language.my_items(), end='')
-        print(', '.join(map(str, my_items)))
+        print(describe_items(my_items))
         print(self.language.opponent_items(), end='')
-        print(', '.join(map(str, opponent_items)))
+        print(describe_items(opponent_items))
         print(self.language.action(), end='')
         print(str(action))
         print(self.language.action_result(), end='')
@@ -48,3 +48,27 @@ class CLIPlayer(PlayerAbstract):
             move = Nothing()
         print('-----------------------------')
         return move
+
+
+def describe_items(items: list[Item]) -> str:
+    items = items.copy()
+    items.sort()
+    ret = []
+    last_item = None
+    count_of_last_item = 1
+    while items or last_item != None:
+        try:
+            item = items.pop()
+        except IndexError:
+            item = None
+        if last_item == item:
+            count_of_last_item += 1
+        elif last_item != None:
+            if count_of_last_item > 1:
+                ret.append(f'{str(last_item)} x{count_of_last_item}')
+            else:
+                ret.append(str(last_item))
+            count_of_last_item = 1
+            last_item = None
+        last_item = item
+    return ', '.join(ret)

--- a/dealer/dealer.py
+++ b/dealer/dealer.py
@@ -1,0 +1,78 @@
+from random import choice
+from engine.engine import PlayerAbstract
+from engine.item import Action, ActionOutcome, ActorAction, InitialShellCount, Item, Nothing, Shell, Shoot
+
+
+class DealerBot(PlayerAbstract):
+    def __init__(self) -> None:
+        super().__init__()
+        self.live_count = 0
+        self.blank_count = 0
+        self.handcuffs_cooldown = 0
+        self.known_shell = None
+        self.gun_handsawed = False
+
+    def make_move(
+            self,
+            my_hp: int,
+            opponent_hp: int,
+            my_items: list[Item],
+            opponent_items: list[Item],
+            action: ActorAction,
+            action_outcome: ActionOutcome,
+            available: list[Action],
+    ):
+        if isinstance(action_outcome, InitialShellCount):
+            self.live_count = action_outcome.live_count
+            self.blank_count = action_outcome.blank_count
+        if isinstance(action, ActorAction):
+            if action.action_taken in [Shoot.You, Shoot.Opponent] and self.handcuffs_cooldown > 0:
+                self.handcuffs_cooldown -= 1
+            # If the action can change our count
+            if action.action_taken in [Item.Beer, Shoot.You, Shoot.Opponent]:
+                self.known_shell = None
+                if action_outcome == Shell.Live:
+                    self.live_count -= 1
+                elif action_outcome == Shell.Blank:
+                    self.blank_count -= 1
+            if action.action_taken == Item.Magnifier:
+                if action_outcome != Shell.Unknown:
+                    self.known_shell = action_outcome
+        if not available:
+            return Nothing()
+        guaranteed_lethal = self.blank_count == 0 or self.known_shell == Shell.Live
+        if Item.Cigarettes in available and my_hp < 4:
+            return Item.Cigarettes
+        if Item.Handcuffs in available and self.handcuffs_cooldown == 0:
+            self.handcuffs_cooldown = 2
+            return Item.Handcuffs
+        if guaranteed_lethal and Item.HandSaw in available and not self.gun_handsawed:
+            self.gun_handsawed = True
+            return Item.HandSaw
+        if Item.Magnifier in available and self.known_shell == None:
+            return Item.Magnifier
+        if self.live_count == 0 or self.known_shell == Shell.Blank:
+            if Item.Beer in available:
+                return Item.Beer
+            else:
+                return Shoot.You
+        if guaranteed_lethal or self.gun_handsawed:
+            self.gun_handsawed = False
+            return Shoot.Opponent
+        option = None
+        while option == None:
+            option = choice(available)
+            if option == Item.HandSaw:
+                if self.gun_handsawed:
+                    option = None
+                else:
+                    self.gun_handsawed = True
+            if option == Item.Handcuffs and self.handcuffs_cooldown > 0:
+                option = None
+            if option == Item.Cigarettes and my_hp >= 4:
+                option = None
+            if option == Item.Magnifier and self.known_shell != None:
+                option = None
+        return option
+
+

--- a/engine/item.py
+++ b/engine/item.py
@@ -1,0 +1,56 @@
+from enum import Enum, auto
+
+class Action:
+    pass
+
+class Item(Action, Enum):
+    Beer = auto()
+    Cigarettes = auto()
+    Handcuffs = auto()
+    HandSaw = auto()
+    Magnifier = auto()
+
+    def __str__(self):
+        return self.name
+
+class Shoot(Action, Enum):
+    You = auto()
+    Opponent = auto()
+
+    def __str__(self):
+        return self.name
+
+class RoundStart(Action):
+    def __str__(self):
+        return f"Round Start"
+
+class Nothing(Action):
+    def __str__(self):
+        return "Nothing"
+
+class ActorAction:
+    def __init__(self, actor, action_taken):
+        self.actor = actor
+        self.action_taken = action_taken
+    
+    def __str__(self):
+        return str(self.actor) + " " + str(self.action_taken)
+
+class ActionOutcome:
+    pass
+
+class Shell(ActionOutcome, Enum):
+    Live = auto()
+    Blank = auto()
+    Unknown = auto()
+
+    def __str__(self):
+        return self.name
+
+class InitialShellCount(ActionOutcome):
+    def __init__(self, live_count, blank_count):
+        self.live_count = live_count
+        self.blank_count = blank_count
+    
+    def __str__(self):
+        return f"LIVE {self.live_count} BLANK {self.blank_count}"

--- a/engine/item.py
+++ b/engine/item.py
@@ -1,14 +1,22 @@
 from enum import Enum, auto
+from functools import total_ordering
 
 class Action:
     pass
 
+@total_ordering
 class Item(Action, Enum):
     Beer = auto()
     Cigarettes = auto()
     Handcuffs = auto()
     HandSaw = auto()
     Magnifier = auto()
+
+    def __le__(self, __value: object) -> bool:
+        if isinstance(__value, Item):
+            return self.value < __value.value
+        else:
+            return False
 
     def __str__(self):
         return self.name

--- a/main.py
+++ b/main.py
@@ -1,12 +1,13 @@
 from cli_player.cli_player import CLIPlayer
 from engine.engine import Engine
 from primitive_bots.random_move_bot import RandomMoveBot
+from dealer.dealer import DealerBot
 from language.language import pick_language
 
 def main():
     language = pick_language()
     player1 = CLIPlayer(input(language.greeting()), language)
-    player2 = RandomMoveBot()
+    player2 = DealerBot()
     print(Engine(player1, player2).start())
 
 

--- a/primitive_bots/random_move_bot.py
+++ b/primitive_bots/random_move_bot.py
@@ -1,5 +1,6 @@
 from random import choice
-from engine.engine import PlayerAbstract, Engine
+from engine.engine import PlayerAbstract
+from engine.item import Action, ActionOutcome, ActorAction, Item, Nothing
 
 
 class RandomMoveBot(PlayerAbstract):
@@ -7,13 +8,13 @@ class RandomMoveBot(PlayerAbstract):
             self,
             my_hp: int,
             opponent_hp: int,
-            my_items: list[str],
-            opponent_items: list[str],
-            action: str,
-            action_result: str,
-            available: list[str],
+            my_items: list[Item],
+            opponent_items: list[Item],
+            action: ActorAction,
+            action_outcome: ActionOutcome,
+            available: list[Action],
     ):
         if not available:
-            return 'NOTHING'
+            return Nothing()
         return choice(available)
 


### PR DESCRIPTION
Hi, this is a pretty large PR. I understand it's probably rude to change this much code without consulting you. I originally wrote this for my own use, but figured that what I had might be worth sharing.

This PR does a few major things

1. Reduce the use of strings throughout the engine, making the engine output easier to work with (in my opinion)
2. Add a dealer bot which simulates the dealer in the official game. It has a few important modifications on top of the random choice bot. I'll describe these at the end.
3. Change the CLI player to provide output that is easier to read, and accept input that is no longer case sensitive.

The dealer bot does a few important things

1. The dealer counts bullets and uses this as part of decision making.
   a. A gun with zero live rounds will never be pointed at the opponent.
   b. A gun with zero blank rounds will never be pointed at itself.
   c. All other scenarios are left up to chance.
3. The dealer remembers what it saw with the magnifier and acts accordingly
4. If the dealer knows that the next shot will be live, it will use a handsaw if available.
5. If the dealer has handcuffs it will use them.
6. If the dealer has cigarettes it will always use them.
7. The dealer will always point the gun at the opponent after using a handsaw
8. The dealer will never use cigarettes if they are already at full
9. The dealer will never use a magnifier if they already know what's at the front of the gun.
10. The dealer will never point a handsawed gun at itself
11. If the dealer knows the next round is a blank, and a beer is available, it will drink the beer